### PR TITLE
Make ES5 Shim optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ module.exports = function (url, size, opts) {
 	});
 
 	if (!opts.disableShim){
-		opts.es5shim = path.relative(path.join(__dirname, 'lib'), es5Shim);
-		es5shim = fs.readFileSync(es5Shim, 'utf8');
+	  opts.es5shim = path.relative(path.join(__dirname, 'lib'), es5Shim);
+	  es5shim = fs.readFileSync(es5Shim, 'utf8');
 	}
 
 	var cp = phantomBridge(path.join(__dirname, 'lib/index.js'), [

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ var base64Stream = require('base64-stream');
 var es5Shim = require.resolve('es5-shim');
 var parseCookiePhantomjs = require('parse-cookie-phantomjs');
 var phantomBridge = require('phantom-bridge');
+var es5shim;
 
 module.exports = function (url, size, opts) {
 	opts = opts || {};
 	opts.url = url;
-	opts.es5shim = path.relative(path.join(__dirname, 'lib'), es5Shim);
 	opts.delay = opts.delay || 0;
 	opts.scale = opts.scale || 1;
 	opts.width = size.split(/x/i)[0] * opts.scale;
@@ -20,6 +20,11 @@ module.exports = function (url, size, opts) {
 		return typeof cookie === 'string' ? parseCookiePhantomjs(cookie) : cookie;
 	});
 
+	if (!opts.disableShim){
+		opts.es5shim = path.relative(path.join(__dirname, 'lib'), es5Shim);
+		es5shim = fs.readFileSync(es5Shim, 'utf8');
+	}
+
 	var cp = phantomBridge(path.join(__dirname, 'lib/index.js'), [
 		'--ignore-ssl-errors=true',
 		'--local-to-remote-url-access=true',
@@ -28,7 +33,6 @@ module.exports = function (url, size, opts) {
 	]);
 
 	var stream = cp.stdout.pipe(base64Stream.decode());
-	var es5shim = fs.readFileSync(es5Shim, 'utf8');
 
 	process.stderr.setMaxListeners(0);
 
@@ -44,7 +48,7 @@ module.exports = function (url, size, opts) {
 			return;
 		}
 
-		if (es5shim.indexOf(data) !== -1) {
+		if (es5shim && es5shim.indexOf(data) !== -1) {
 			return;
 		}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,9 +51,9 @@ page.onError = function (err, trace) {
 };
 
 if (opts.es5shim){
-	page.onResourceReceived = function () {
-		page.injectJs(opts.es5shim);
-	};	
+  page.onResourceReceived = function () {
+    page.injectJs(opts.es5shim);
+  };	
 }
 
 page.viewportSize = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,9 +50,11 @@ page.onError = function (err, trace) {
 	].join('\n'));
 };
 
-page.onResourceReceived = function () {
-	page.injectJs(opts.es5shim);
-};
+if (opts.es5shim){
+	page.onResourceReceived = function () {
+		page.injectJs(opts.es5shim);
+	};	
+}
 
 page.viewportSize = {
 	width: opts.width,


### PR DESCRIPTION
- In some cases, the ES5 shim may not be warranted or necessary, so make it optional with a disableShim option.  This should not affect anyone currently using screenshot-stream.
